### PR TITLE
Query updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Rest.config = config;
 Query record via a static method on the `RestClient`:
 
 ```typescript
-Rest.query<Account>(Account, 'SELECT Id FROM Account');
+let accs: Account[] = Rest.query(Account, 'SELECT Id FROM Account');
 ```
 
 ** Note: we have to specify the account as a generic and pass the type into the first aguement because we use Object.Assign to make the returned json instances implement `RestObject`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-force",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "a typescript client for connecting with salesforce APIs",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/lib/rest.ts
+++ b/src/lib/rest.ts
@@ -25,16 +25,16 @@ export class Rest {
     })
   }
 
-    // get records of type T.  Do magic to cast plain json to T
-  public static async query<T extends SObject> (type: { new(): T ;}, query: string): Promise<QueryResponse<T>> {
+  // get records of type T.  Do magic to cast plain json to T
+  public static async query(type: { new(): SObject ;}, query: string): Promise<QueryResponse> {
     let qryString = encodeURIComponent(query)
-    return new Promise<QueryResponse<T>>((resolve, reject) => {
+    return new Promise<QueryResponse>((resolve, reject) => {
       if (!this._instance) {
         this._instance = new this()
       }
       this._instance.request.get(`/query?q=${qryString}`)
             .then((response) => {
-              let sobs: Array<T> = []
+              let sobs: Array<SObject> = []
               for (let i = 0; i < response.data.records.length; i++) {
                 let sob = Object.assign(new type(), response.data.records[i])
                 sobs.push(sob)
@@ -53,7 +53,7 @@ export class Rest {
 
 }
 
-export interface QueryResponse<T> {
+export interface QueryResponse {
   totalSize: number
-  records: T[]
+  records: any
 }

--- a/src/lib/sObject.ts
+++ b/src/lib/sObject.ts
@@ -28,10 +28,7 @@ export class RestObject extends SObject {
   constructor (type: string) {
     super(type)
   }
-  public static async query<T extends RestObject> (type: { new(): T; }, query: string): Promise<T[]> {
-    const data = await Rest.query<T>(type, query)
-    return data.records
-  }
+
   public async insert (): Promise<DMLResponse> {
     try {
       const response = await this.generateCall(`/sobjects/${this.attributes.type}/`, this)


### PR DESCRIPTION
Moved query back to static on `Rest`.  Reduced need to type generically