### PR TITLE
fixed #5. refactored decorators to single item.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "typescript.tsdk": "node_modules/typescript/lib"
+    "typescript.tsdk": "node_modules/typescript/lib",
+    "editor.tabSize": 2
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ a typescript client for connecting with salesforce APIs.  Currently meant to run
 
 This library is intended to use with code generation.  Files can be generated using the following command:
 
-`ts-force-gen --accessToken '123abc' --instanceUrl https://cs65.my.salesforce.com --sobs Account,Contact --outputFile ./tst/test.ts`
+`ts-force-gen --accessToken '123abc' --instanceUrl https://cs65.my.salesforce.com --sobs Account,Contact --outputFile ./src/generated/sobs.ts`
 
 `--accessToken|-a`: access token to connect to tooling API wit
 `--instanceUrl|-i`: host url of the org your connecting with
@@ -69,13 +69,21 @@ Query record via a static method on each generated claass.
 let accs: Account[] = Account.retrieve('SELECT Id FROM Account');
 ```
 
-#### relationships
+#### Relationships
+Both Parent & Child relationships are supported.  Returned objects are instances of `RestObject` and you can permform DML.
 
 ```typescript
-let contacts: Contact[] = Account.retrieve('SELECT Name, Account.Id, Account.Name FROM Contact LIMIT 1');
-let acc = contact[0].Account;
-acc.Name = 'New Name';
-acc.update();
+
+let accs: Account[] = await Account.retrieve(
+  `SELECT Id, Name, Website, Active__c, (SELECT Id, Name, Email, Parent_Object__r.Id, Parent_Object__r.Name FROM Contacts) FROM Account WHERE Id = '0010m000006vmwJ'`
+);
+
+let contact = records[0].Contacts[0];
+contact.Name = 'new name';
+await contact.update();
+let parentObj = contact.Parent_Object__r;
+parentObj.Account__c = records[0].Id;
+await parentObj.update();
 ```
 
 ### Record DML

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-force",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-force",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "a typescript client for connecting with salesforce APIs",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "license": "MIT",
   "scripts": {
     "clean-build": "rm -r -f ./build && npm run build",
+    "link": "npm run clean-build && npm link",
     "pretest": "tsc",
     "test": "mocha",
     "build": "tsc -p tsconfig.build.json",

--- a/src/gen/sObjectGenerator.ts
+++ b/src/gen/sObjectGenerator.ts
@@ -6,186 +6,186 @@ const superClass = 'RestObject';
 
 export class SObjectGenerator {
 
-    public apiNames: string[];
-    public sourceFile: SourceFile;
+  public apiNames: string[];
+  public sourceFile: SourceFile;
 
-    constructor(sourceFile: SourceFile, apiNames: string[]) {
-        this.apiNames = apiNames;
-        this.sourceFile = sourceFile;
+  constructor(sourceFile: SourceFile, apiNames: string[]) {
+    this.apiNames = apiNames;
+    this.sourceFile = sourceFile;
+  }
+
+  public async generateFile() {
+    //add imports
+    this.sourceFile.addImport({
+      moduleSpecifier: 'ts-force',
+      namedImports: [
+        { name: 'RestObject' },
+        { name: 'SObject' },
+        { name: 'sField' }
+      ]
+    });
+
+    for (var i = 0; i < this.apiNames.length; i++) {
+      await this.generateSObjectClass(this.apiNames[i]);
     }
 
-    public async generateFile() {
-        //add imports
-        this.sourceFile.addImport({
-            moduleSpecifier: 'ts-force',
-            namedImports: [
-                { name: 'RestObject' },
-                { name: 'SObject' },
-                { name: 'sField' }
-            ]
-        });
+  }
 
-        for (var i = 0; i < this.apiNames.length; i++) {
-            await this.generateSObjectClass(this.apiNames[i]);
+  //class generation
+  public async generateSObjectClass(apiName: string): Promise<void> {
+
+    let sobDescribe = await this.retrieveDescribe(apiName);
+
+    let members = sobDescribe.fields;
+    let children = sobDescribe.childRelationships;
+
+    let className: string = this.sanatizeClassName(apiName);
+
+    let props: PropertyDeclarationStructure[] = [];
+
+    //add children relationships
+    children.forEach(child => {
+      if (this.apiNames.indexOf(child.childSObject) > -1 && child.childSObject != apiName) {
+        let referenceClass = this.sanatizeClassName(child.childSObject);
+
+        let decoratorProps = {
+          apiName: child.relationshipName,
+          readOnly: true,
+          required: false,
+          childRelationship: true,
+          reference: referenceClass
         }
 
-    }
-
-    //class generation
-    public async generateSObjectClass(apiName: string): Promise<void> {
-
-        let sobDescribe = await this.retrieveDescribe(apiName);
-
-        let members = sobDescribe.fields;
-        let children = sobDescribe.childRelationships;
-
-        let className: string = this.sanatizeClassName(apiName);
-
-        let props: PropertyDeclarationStructure[] = [];
-
-        //add children relationships
-        children.forEach(child => {
-            if (this.apiNames.indexOf(child.childSObject) > -1 && child.childSObject != apiName) {
-                let referenceClass = this.sanatizeClassName(child.childSObject);
-
-                let decoratorProps = {
-                    apiName: child.relationshipName,
-                    readOnly: true,
-                    required: false,
-                    childRelationship: true,
-                    reference: referenceClass
-                }
-
-                props.push({
-                    name: child.relationshipName,
-                    type: `${referenceClass}[]`,
-                    scope: Scope.Public,
-                    decorators: [
-                        this.generateDecorator(decoratorProps)
-                    ]
-                });
-            }
+        props.push({
+          name: child.relationshipName,
+          type: `${referenceClass}[]`,
+          scope: Scope.Public,
+          decorators: [
+            this.generateDecorator(decoratorProps)
+          ]
         });
+      }
+    });
 
-        //add members
-        members.forEach(field => {
-            let docs: JSDocStructure[] = [];
-            if (field.inlineHelpText != null) {
-                docs.push({ description: field.inlineHelpText });
-            }
+    //add members
+    members.forEach(field => {
+      let docs: JSDocStructure[] = [];
+      if (field.inlineHelpText != null) {
+        docs.push({ description: field.inlineHelpText });
+      }
 
-            //only include reference types if we are also generating the referenced class
-            if (field.type == 'reference' && this.apiNames.indexOf(field.referenceTo[0]) > -1) {
-                let referenceClass: string;
+      //only include reference types if we are also generating the referenced class
+      if (field.type == 'reference' && this.apiNames.indexOf(field.referenceTo[0]) > -1) {
+        let referenceClass: string;
 
-                if (field.referenceTo.length > 1) {
-                    referenceClass = 'any'; //polymorphic?
-                } else {
-                    referenceClass = this.sanatizeClassName(field.referenceTo[0]);
-                }
-                let refApiName = field.referenceTo[0]; //polymorphic not support
-
-                let decoratorProps = {
-                    apiName: field.relationshipName,
-                    readOnly: true,
-                    required: false,
-                    childRelationship: false,
-                    reference: referenceClass
-                }
-
-                props.push({
-                    name: field.relationshipName,
-                    type: referenceClass,
-                    scope: Scope.Public,
-                    decorators: [
-                        this.generateDecorator(decoratorProps)
-                    ],
-                    docs: docs
-                });
-            }
-
-            let prop: PropertyDeclarationStructure = {
-                name: field.name,
-                type: this.mapSObjectType(field.type),
-                scope: Scope.Public,
-                decorators: [this.getDecorator(field)],
-                docs: docs
-            }
-
-            props.push(prop);
-        });
-
-        const classDeclaration = this.sourceFile.addClass({
-            name: className,
-            extends: superClass,
-            isExported: true,
-            properties: props
-        });
-
-        const constr = classDeclaration.addConstructor();
-        constr.setBodyText(`super('${apiName}');`);
-
-        const qryMethod = classDeclaration.addMethod({
-            name: 'retrieve',
-            isStatic: true,
-            scope: Scope.Public,
-            parameters: [
-                { name: 'qry', type: 'string' }
-            ],
-            returnType: `Promise<${className}[]>`,
-            isAsync: true
-        });
-
-        qryMethod.setBodyText(
-            `return await ${superClass}.query<${className}>(${className}, qry);`
-        );
-
-    }
-
-    private async retrieveDescribe(apiName: string): Promise<SObjectDescribe> {
-        return await Rest.Instance.getSObjectDescribe(apiName);
-    }
-
-    private sanatizeClassName(apiName: string): string {
-        return apiName.replace('__c', '').replace('_', '');
-    }
-
-    private mapSObjectType(sfType: string): string {
-        switch (sfType) {
-            case 'double':
-            case 'integer':
-            case 'currency':
-                return 'number';
-            case 'reference':
-            case 'string':
-            case 'picklist':
-            case 'id':
-            default:
-                return 'string';
+        if (field.referenceTo.length > 1) {
+          referenceClass = 'any'; //polymorphic?
+        } else {
+          referenceClass = this.sanatizeClassName(field.referenceTo[0]);
         }
-    }
+        let refApiName = field.referenceTo[0]; //polymorphic not support
 
-    private generateDecorator(decoratorProps: any) {
-        var ref = decoratorProps.reference != null ? `()=>{return ${decoratorProps.reference}}`: 'undefined'
-        return {
-            name: `sField`,
-            arguments: [
-                `{apiName: '${decoratorProps.apiName}', readOnly: ${decoratorProps.readOnly}, required: ${decoratorProps.required}, reference:${ref}, childRelationship: ${decoratorProps.childRelationship}}`
-            ]
+        let decoratorProps = {
+          apiName: field.relationshipName,
+          readOnly: true,
+          required: false,
+          childRelationship: false,
+          reference: referenceClass
         }
+
+        props.push({
+          name: field.relationshipName,
+          type: referenceClass,
+          scope: Scope.Public,
+          decorators: [
+            this.generateDecorator(decoratorProps)
+          ],
+          docs: docs
+        });
+      }
+
+      let prop: PropertyDeclarationStructure = {
+        name: field.name,
+        type: this.mapSObjectType(field.type),
+        scope: Scope.Public,
+        decorators: [this.getDecorator(field)],
+        docs: docs
+      }
+
+      props.push(prop);
+    });
+
+    const classDeclaration = this.sourceFile.addClass({
+      name: className,
+      extends: superClass,
+      isExported: true,
+      properties: props
+    });
+
+    const constr = classDeclaration.addConstructor();
+    constr.setBodyText(`super('${apiName}');`);
+
+    const qryMethod = classDeclaration.addMethod({
+      name: 'retrieve',
+      isStatic: true,
+      scope: Scope.Public,
+      parameters: [
+        { name: 'qry', type: 'string' }
+      ],
+      returnType: `Promise<${className}[]>`,
+      isAsync: true
+    });
+
+    qryMethod.setBodyText(
+      `return await ${superClass}.query<${className}>(${className}, qry);`
+    );
+
+  }
+
+  private async retrieveDescribe(apiName: string): Promise<SObjectDescribe> {
+    return await Rest.Instance.getSObjectDescribe(apiName);
+  }
+
+  private sanatizeClassName(apiName: string): string {
+    return apiName.replace('__c', '').replace('_', '');
+  }
+
+  private mapSObjectType(sfType: string): string {
+    switch (sfType) {
+      case 'double':
+      case 'integer':
+      case 'currency':
+      return 'number';
+      case 'reference':
+      case 'string':
+      case 'picklist':
+      case 'id':
+      default:
+      return 'string';
+    }
+  }
+
+  private generateDecorator(decoratorProps: any) {
+    var ref = decoratorProps.reference != null ? `()=>{return ${decoratorProps.reference}}`: 'undefined'
+    return {
+      name: `sField`,
+      arguments: [
+        `{apiName: '${decoratorProps.apiName}', readOnly: ${decoratorProps.readOnly}, required: ${decoratorProps.required}, reference:${ref}, childRelationship: ${decoratorProps.childRelationship}}`
+      ]
+    }
+  }
+
+  private getDecorator(field: Field): DecoratorStructure {
+    let decoratorProps = {
+      apiName: field.name,
+      readOnly: field.updateable == false && field.createable == false,
+      required: (field.createable || field.updateable) && field.nillable == false,
+      childRelationship: false,
+      reference: null
     }
 
-    private getDecorator(field: Field): DecoratorStructure {
-         let decoratorProps = {
-                    apiName: field.name,
-                    readOnly: field.updateable == false && field.createable == false,
-                    required: (field.createable || field.updateable) && field.nillable == false,
-                    childRelationship: false,
-                    reference: null
-                }
-
-        return this.generateDecorator(decoratorProps)
-    }
+    return this.generateDecorator(decoratorProps)
+  }
 
 
 }

--- a/src/gen/sObjectGenerator.ts
+++ b/src/gen/sObjectGenerator.ts
@@ -1,180 +1,191 @@
 import { Scope, SourceFile, PropertyDeclarationStructure, DecoratorStructure, JSDocStructure } from "ts-simple-ast";
 import { Rest } from "../main/lib/rest";
 import { Field, SObjectDescribe, ChildRelationship } from "../main/lib/SObjectDescribe";
-
+import { SFieldProperties } from '../main/lib/sObjectDecorators';
 const superClass = 'RestObject';
 
 export class SObjectGenerator {
 
-  public apiNames: string[];
-  public sourceFile: SourceFile;
+    public apiNames: string[];
+    public sourceFile: SourceFile;
 
-  constructor(sourceFile: SourceFile, apiNames: string[]) {
-    this.apiNames = apiNames;
-    this.sourceFile = sourceFile;
-  }
-
-  public async generateFile() {
-    //add imports
-    this.sourceFile.addImport({
-      moduleSpecifier: 'ts-force',
-      namedImports: [
-        { name: 'RestObject' },
-        { name: 'SObject' },
-        { name: 'reference' },
-        { name: 'required' },
-        { name: 'readonly' },
-      ]
-    });
-
-    for (var i = 0; i < this.apiNames.length; i++) {
-      await this.generateSObjectClass(this.apiNames[i]);
+    constructor(sourceFile: SourceFile, apiNames: string[]) {
+        this.apiNames = apiNames;
+        this.sourceFile = sourceFile;
     }
 
-  }
-
-  //class generation
-  public async generateSObjectClass(apiName: string): Promise<void> {
-
-    let sobDescribe = await this.retrieveDescribe(apiName);
-
-    let members = sobDescribe.fields;
-    let children = sobDescribe.childRelationships;
-
-    let className: string = this.sanatizeClassName(apiName);
-
-    let props: PropertyDeclarationStructure[] = [];
-
-    //add children relationships
-    children.forEach(child => {
-      if (this.apiNames.indexOf(child.childSObject) > -1 && child.childSObject != apiName) {
-        let referenceClass = this.sanatizeClassName(child.childSObject);
-
-        props.push({
-          name: child.relationshipName,
-          type: `${referenceClass}[]`,
-          scope: Scope.Public
-          //TODO add decorator for child relationship
+    public async generateFile() {
+        //add imports
+        this.sourceFile.addImport({
+            moduleSpecifier: 'ts-force',
+            namedImports: [
+                { name: 'RestObject' },
+                { name: 'SObject' },
+                { name: 'sField' }
+            ]
         });
-      }
-    });
 
-    //add members
-    members.forEach(field => {
-      let docs: JSDocStructure[] = [];
-      if (field.inlineHelpText != null) {
-        docs.push({ description: field.inlineHelpText });
-      }
-
-      //only include reference types if we are also generating the referenced class
-      if (field.type == 'reference' && this.apiNames.indexOf(field.referenceTo[0]) > -1) {
-        let referenceClass: string;
-
-        if (field.referenceTo.length > 1) {
-          referenceClass = 'any'; //polymorphic?
-        } else {
-          referenceClass = this.sanatizeClassName(field.referenceTo[0]);
+        for (var i = 0; i < this.apiNames.length; i++) {
+            await this.generateSObjectClass(this.apiNames[i]);
         }
-        let refApiName = field.referenceTo[0]; //polymorphic not support
 
-        props.push({
-          name: field.relationshipName,
-          type: referenceClass,
-          scope: Scope.Public,
-          decorators: [{
-            name: `reference(${referenceClass})`
-          }],
-          docs: docs
+    }
+
+    //class generation
+    public async generateSObjectClass(apiName: string): Promise<void> {
+
+        let sobDescribe = await this.retrieveDescribe(apiName);
+
+        let members = sobDescribe.fields;
+        let children = sobDescribe.childRelationships;
+
+        let className: string = this.sanatizeClassName(apiName);
+
+        let props: PropertyDeclarationStructure[] = [];
+
+        //add children relationships
+        children.forEach(child => {
+            if (this.apiNames.indexOf(child.childSObject) > -1 && child.childSObject != apiName) {
+                let referenceClass = this.sanatizeClassName(child.childSObject);
+
+                let decoratorProps = {
+                    apiName: child.relationshipName,
+                    readOnly: true,
+                    required: false,
+                    childRelationship: true,
+                    reference: referenceClass
+                }
+
+                props.push({
+                    name: child.relationshipName,
+                    type: `${referenceClass}[]`,
+                    scope: Scope.Public,
+                    decorators: [
+                        this.generateDecorator(decoratorProps)
+                    ]
+                });
+            }
         });
-      }
 
-      let prop: PropertyDeclarationStructure = {
-        name: field.name,
-        type: this.mapSObjectType(field.type),
-        scope: Scope.Public,
-        decorators: this.getDecorators(field),
-        docs: docs
-      }
+        //add members
+        members.forEach(field => {
+            let docs: JSDocStructure[] = [];
+            if (field.inlineHelpText != null) {
+                docs.push({ description: field.inlineHelpText });
+            }
 
-      props.push(prop);
-    });
+            //only include reference types if we are also generating the referenced class
+            if (field.type == 'reference' && this.apiNames.indexOf(field.referenceTo[0]) > -1) {
+                let referenceClass: string;
 
-    const classDeclaration = this.sourceFile.addClass({
-      name: className,
-      extends: superClass,
-      isExported: true,
-      properties: props
-    });
+                if (field.referenceTo.length > 1) {
+                    referenceClass = 'any'; //polymorphic?
+                } else {
+                    referenceClass = this.sanatizeClassName(field.referenceTo[0]);
+                }
+                let refApiName = field.referenceTo[0]; //polymorphic not support
 
-    const constr = classDeclaration.addConstructor();
-    constr.setBodyText(`super('${apiName}');`);
+                let decoratorProps = {
+                    apiName: field.relationshipName,
+                    readOnly: true,
+                    required: false,
+                    childRelationship: false,
+                    reference: referenceClass
+                }
 
-    const qryMethod = classDeclaration.addMethod({
-      name: 'retrieve',
-      isStatic: true,
-      scope: Scope.Public,
-      parameters: [
-        { name: 'qry', type: 'string' }
-      ],
-      returnType: `Promise<${className}[]>`,
-      isAsync: true
-    });
+                props.push({
+                    name: field.relationshipName,
+                    type: referenceClass,
+                    scope: Scope.Public,
+                    decorators: [
+                        this.generateDecorator(decoratorProps)
+                    ],
+                    docs: docs
+                });
+            }
 
-    qryMethod.setBodyText(
-      `return await ${superClass}.query<${className}>(${className}, qry);`
-    );
+            let prop: PropertyDeclarationStructure = {
+                name: field.name,
+                type: this.mapSObjectType(field.type),
+                scope: Scope.Public,
+                decorators: [this.getDecorator(field)],
+                docs: docs
+            }
 
-  }
+            props.push(prop);
+        });
 
-  private async retrieveDescribe(apiName: string): Promise<SObjectDescribe> {
-    return await Rest.Instance.getSObjectDescribe(apiName);
-  }
+        const classDeclaration = this.sourceFile.addClass({
+            name: className,
+            extends: superClass,
+            isExported: true,
+            properties: props
+        });
 
-  private sanatizeClassName(apiName: string): string {
-    return apiName.replace('__c', '').replace('_', '');
-  }
+        const constr = classDeclaration.addConstructor();
+        constr.setBodyText(`super('${apiName}');`);
 
-  private mapSObjectType(sfType: string): string {
-    switch (sfType) {
-      case 'double':
-      case 'integer':
-      case 'currency':
-        return 'number';
-      case 'reference':
-      case 'string':
-      case 'picklist':
-      case 'id':
-      default:
-        return 'string';
-    }
-  }
+        const qryMethod = classDeclaration.addMethod({
+            name: 'retrieve',
+            isStatic: true,
+            scope: Scope.Public,
+            parameters: [
+                { name: 'qry', type: 'string' }
+            ],
+            returnType: `Promise<${className}[]>`,
+            isAsync: true
+        });
 
-  private getDecorators(field: Field): DecoratorStructure[] {
-    let decorators: DecoratorStructure[] = [];
-    if (field.updateable == false && field.createable == false) {
-      decorators.push({
-        name: 'readonly()'
-      });
-    }
-    // else if(field.updateable == false && field.createable == true){
-    //   decorators.push({
-    //     name:'CreateOnly'
-    //   })
-    // }else if(field.updateable == true && field.createable == false){
-    //   decorators.push({
-    //     name:'UpdateOnly'
-    //   })
-    // }
+        qryMethod.setBodyText(
+            `return await ${superClass}.query<${className}>(${className}, qry);`
+        );
 
-    //this should maybe be managed by making prop required... although that makes querying inconvient
-    if ((field.createable || field.updateable) && field.nillable == false) {
-      decorators.push({
-        name: 'required()'
-      });
     }
 
-    return decorators;
-  }
+    private async retrieveDescribe(apiName: string): Promise<SObjectDescribe> {
+        return await Rest.Instance.getSObjectDescribe(apiName);
+    }
+
+    private sanatizeClassName(apiName: string): string {
+        return apiName.replace('__c', '').replace('_', '');
+    }
+
+    private mapSObjectType(sfType: string): string {
+        switch (sfType) {
+            case 'double':
+            case 'integer':
+            case 'currency':
+                return 'number';
+            case 'reference':
+            case 'string':
+            case 'picklist':
+            case 'id':
+            default:
+                return 'string';
+        }
+    }
+
+    private generateDecorator(decoratorProps: any) {
+        var ref = decoratorProps.reference != null ? `()=>{return ${decoratorProps.reference}}`: 'undefined'
+        return {
+            name: `sField`,
+            arguments: [
+                `{apiName: '${decoratorProps.apiName}', readOnly: ${decoratorProps.readOnly}, required: ${decoratorProps.required}, reference:${ref}, childRelationship: ${decoratorProps.childRelationship}}`
+            ]
+        }
+    }
+
+    private getDecorator(field: Field): DecoratorStructure {
+         let decoratorProps = {
+                    apiName: field.name,
+                    readOnly: field.updateable == false && field.createable == false,
+                    required: (field.createable || field.updateable) && field.nillable == false,
+                    childRelationship: false,
+                    reference: null
+                }
+
+        return this.generateDecorator(decoratorProps)
+    }
 
 
 }

--- a/src/main/lib/sObject.ts
+++ b/src/main/lib/sObject.ts
@@ -94,7 +94,7 @@ export abstract class RestObject extends SObject {
   }
 
   //removes any readonly/reference properties to prepare for update/insert
-  private prepareData(): any{
+  private prepareData(): any {
     let data = Object.assign({}, this);
     //remove anything that we can't update
     for (var i in data) {
@@ -102,11 +102,10 @@ export abstract class RestObject extends SObject {
       if (data.hasOwnProperty(i)) {
         //remove readonly && reference types
         let sFieldProps = getSFieldProps(this, i);
-        if(sFieldProps){
-            if (sFieldProps.readOnly || sFieldProps.reference != null) {
-            console.log(`removed readonly/reference field: ${i}`)
+        if (sFieldProps) {
+          if (sFieldProps.readOnly || sFieldProps.reference != null) {
             data[i] = undefined;
-            }
+          }
         }
       }
     }
@@ -114,8 +113,7 @@ export abstract class RestObject extends SObject {
   }
 
   //copies data from a json object to restobject
-  private static mapData(sob: SObject, data: any): SObject{
-    console.log(data);
+  private static mapData(sob: SObject, data: any): SObject {
     //remove anything that we can't update
     for (var i in data) {
       //clean properties
@@ -124,22 +122,22 @@ export abstract class RestObject extends SObject {
 
         let sFieldProps = getSFieldProps(sob, i);
 
-        if(sFieldProps){
-            if (sFieldProps.reference != null) {
-                var type: { new(): SObject; } = sFieldProps.reference();
-                if(sFieldProps.childRelationship == true){
-                    sob[i] = [];
-                    if(data[i]){
-                        data[i].records.forEach(record=>{
-                            sob[i].push(RestObject.mapData(new type(), record));
-                        })
-                    }
-                }else{
-                    sob[i] = RestObject.mapData(new type(), data[i]);
-                }
-            }else{
-                sob[i] = data[i];
+        if (sFieldProps) {
+          if (sFieldProps.reference != null) {
+            var type: { new(): SObject; } = sFieldProps.reference();
+            if (sFieldProps.childRelationship == true) {
+              sob[i] = [];
+              if (data[i]) {
+                data[i].records.forEach(record => {
+                  sob[i].push(RestObject.mapData(new type(), record));
+                })
+              }
+            } else {
+              sob[i] = RestObject.mapData(new type(), data[i]);
             }
+          } else {
+            sob[i] = data[i];
+          }
         }
       }
     }

--- a/src/main/lib/sObject.ts
+++ b/src/main/lib/sObject.ts
@@ -1,6 +1,6 @@
 import { Rest, QueryResponse } from './rest';
 import { AxiosResponse } from 'axios';
-import { isReadOnly, getReferenceTypeConstructor } from './sObjectDecorators';
+import { getSFieldProps, SFieldProperties } from './sObjectDecorators';
 /* Base SObject */
 
 export class SObjectAttributes {
@@ -25,7 +25,7 @@ export interface DMLResponse {
   success: boolean;
 }
 
-export class RestObject extends SObject {
+export abstract class RestObject extends SObject {
 
   constructor(type: string) {
     super(type);
@@ -43,7 +43,7 @@ export class RestObject extends SObject {
       }
       return sobs;
     } catch (error) {
-      console.log(error.response.data);
+      console.log(error);
       return error;
     }
   }
@@ -101,9 +101,12 @@ export class RestObject extends SObject {
       //clean properties
       if (data.hasOwnProperty(i)) {
         //remove readonly && reference types
-        if (isReadOnly(this, i) || getReferenceTypeConstructor(this, i) != null) {
-          console.log(`removed readonly/reference field: ${i}`)
-          data[i] = undefined;
+        let sFieldProps = getSFieldProps(this, i);
+        if(sFieldProps){
+            if (sFieldProps.readOnly || sFieldProps.reference != null) {
+            console.log(`removed readonly/reference field: ${i}`)
+            data[i] = undefined;
+            }
         }
       }
     }
@@ -112,16 +115,31 @@ export class RestObject extends SObject {
 
   //copies data from a json object to restobject
   private static mapData(sob: SObject, data: any): SObject{
+    console.log(data);
     //remove anything that we can't update
     for (var i in data) {
       //clean properties
       if (data.hasOwnProperty(i)) {
-        //remove readonly && reference types
-        var type: { new(): SObject; } = getReferenceTypeConstructor(sob, i)
-        if (type != null) {
-          sob[i] = RestObject.mapData(new type(), data[i]);
-        }else{
-          sob[i] = data[i];
+        //get decorators
+
+        let sFieldProps = getSFieldProps(sob, i);
+
+        if(sFieldProps){
+            if (sFieldProps.reference != null) {
+                var type: { new(): SObject; } = sFieldProps.reference();
+                if(sFieldProps.childRelationship == true){
+                    sob[i] = [];
+                    if(data[i]){
+                        data[i].records.forEach(record=>{
+                            sob[i].push(RestObject.mapData(new type(), record));
+                        })
+                    }
+                }else{
+                    sob[i] = RestObject.mapData(new type(), data[i]);
+                }
+            }else{
+                sob[i] = data[i];
+            }
         }
       }
     }

--- a/src/main/lib/sObjectDecorators.ts
+++ b/src/main/lib/sObjectDecorators.ts
@@ -5,11 +5,11 @@ import { SObject } from './SObject';
 const sFieldMetadataKey = Symbol("sField");
 
 export class SFieldProperties{
-    public apiName: string;
-    public readOnly: boolean;
-    public reference: () => { new(): SObject; }
-    public required: boolean;
-    public childRelationship: boolean;
+  public apiName: string;
+  public readOnly: boolean;
+  public reference: () => { new(): SObject; }
+  public required: boolean;
+  public childRelationship: boolean;
 }
 
 export function sField(props: SFieldProperties) {

--- a/src/main/lib/sObjectDecorators.ts
+++ b/src/main/lib/sObjectDecorators.ts
@@ -1,33 +1,21 @@
-import "reflect-metadata";
+import { ChildRelationship } from './sObjectDescribe';
+import 'reflect-metadata';
 import { SObject } from './SObject';
 
-const requiredMetadataKey = Symbol("required");
+const sFieldMetadataKey = Symbol("sField");
 
-export function required() {
-  return Reflect.metadata(requiredMetadataKey, true);
+export class SFieldProperties{
+    public apiName: string;
+    public readOnly: boolean;
+    public reference: () => { new(): SObject; }
+    public required: boolean;
+    public childRelationship: boolean;
 }
 
-export function isRequired(target: any, propertyKey: string) {
-  return Reflect.getMetadata(requiredMetadataKey, target, propertyKey);
+export function sField(props: SFieldProperties) {
+  return Reflect.metadata(sFieldMetadataKey, props);
 }
 
-
-const readonlyMetadataKey = Symbol("readonly");
-
-export function readonly() {
-  return Reflect.metadata(readonlyMetadataKey, true);
-}
-
-export function isReadOnly(target: any, propertyKey: string) {
-  return Reflect.getMetadata(readonlyMetadataKey, target, propertyKey);
-}
-
-const referenceMetadataKey = Symbol("reference");
-
-export function reference(type: { new(): SObject; }) {
-  return Reflect.metadata(referenceMetadataKey, type);
-}
-
-export function getReferenceTypeConstructor(target: any, propertyKey: string): { new(): SObject; } {
-  return Reflect.getMetadata(referenceMetadataKey, target, propertyKey);
+export function getSFieldProps(target: any, propertyKey: string): SFieldProperties{
+  return Reflect.getMetadata(sFieldMetadataKey, target, propertyKey);
 }


### PR DESCRIPTION
This code really needs some refactoring but the relationships are now working!

Now you can do crazy ish like this:

```typescript
Account.retrieve(
  `SELECT Id, Name, Website, Active__c, (SELECT Id, Name, Email, Parent_Object__r.Id, Parent_Object__r.Name FROM Contacts) FROM Account WHERE Id = '0010m000006vmwJ'`
).then((records) => {
  let contact = records[0].Contacts[0];
  let parentObj = contact.Parent_Object__r;
  parentObj.Account__c = records[0].Id;
  parentObj.update();
}).catch(error=>{
    console.log(error)
    return;
});
```
