### PR TITLE
Allows for strict null checks to be allowed

### DIFF
--- a/src/main/lib/sObjectDecorators.ts
+++ b/src/main/lib/sObjectDecorators.ts
@@ -7,7 +7,7 @@ const sFieldMetadataKey = Symbol('sField');
 export class SFieldProperties {
     public apiName: string;
     public readOnly: boolean;
-    public reference: () => { new(): RestObject; };
+    public reference?: () => { new(): RestObject; };
     public required: boolean;
     public childRelationship: boolean;
     public salesforceType: string;

--- a/test/lib/generatedSobs.ts
+++ b/test/lib/generatedSobs.ts
@@ -76,7 +76,7 @@ export interface AccountFields {
 /**
  * Generated class for Account
  */
-export class Account extends RestObject  implements AccountFields {
+export class Account extends RestObject implements AccountFields {
     @sField({ apiName: 'Contacts', readOnly: true, required: false, reference: () => { return Contact; }, childRelationship: true, salesforceType: 'undefined' })
     contacts: Contact[];
     @sField({ apiName: 'Id', readOnly: true, required: false, reference: undefined, childRelationship: false, salesforceType: 'id' })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "listFiles": false,
     "traceResolution": false,
     "experimentalDecorators": true,
+    "strictNullChecks": true,
     "pretty": true,
     "lib" : [
       "es6"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "listFiles": false,
     "traceResolution": false,
     "experimentalDecorators": true,
-    "strictNullChecks": true,
     "pretty": true,
     "lib" : [
       "es6"


### PR DESCRIPTION
Marks "reference" as optional, so when we generate it as undefined it stops throwing a type error for TS configs that have "strictNullCheck" set to true 