### PR TITLE
feat: Allows a Rest instance to be passed to retrieve on codegen'd objects

### DIFF
--- a/ts-force-gen/src/sObjectGenerator.ts
+++ b/ts-force-gen/src/sObjectGenerator.ts
@@ -164,13 +164,14 @@ export class SObjectGenerator {
             isStatic: true,
             scope: Scope.Public,
             parameters: [
-                { name: 'qryParam', type: `((fields: FieldResolver<${className}>) => SOQLQueryParams) | string` }
+                { name: 'qryParam', type: `((fields: FieldResolver<${className}>) => SOQLQueryParams) | string` },
+                { name: 'restInstance', type: 'Rest', hasQuestionToken: true }
             ],
             returnType: `Promise<${className}[]>`,
             isAsync: true,
             bodyText: `
             let qry = typeof qryParam === 'function' ? buildQuery(${className}, qryParam) : qryParam;
-            return await ${SUPER_CLASS}.query<${className}>(${className}, qry);
+            return await ${SUPER_CLASS}.query<${className}>(${className}, qry, restInstance);
             `
         });
 


### PR DESCRIPTION
There is an example in the readme where it states you can do the following: 
`let otherConnSelect = await Account.retrieve('select Id from Account', otherClient);`

Codegen doesn't actually add in the second parameter to allow this. This PR adds this in.

I wasn't sure how to add tests for this functionality.