### PR TITLE
Fix: missing types in SalesforceFieldType enum

### DIFF
--- a/ts-force/src/rest/sObjectDecorators.ts
+++ b/ts-force/src/rest/sObjectDecorators.ts
@@ -23,7 +23,9 @@ export enum SalesforceFieldType {
     LOCATION      = 'location',
     ID            = 'id',
     BASE64        = 'base64',
-    ANYTYPE       = 'anytype'
+    ANYTYPE       = 'anytype',
+    TIME = 'time',
+    ENCRYPTEDSTRING = 'encryptedstring'
 }
 const sFieldMetadataKey = Symbol('sField');
 


### PR DESCRIPTION
Hi guys,

We encountered an issue when using `ts-force` in our project. We were using `npx ts-force-gen -j tsforce-gen.config.json` to generate classes. In the generated class, some of the `salesforceType` is not stored in `SalesforceFieldType` enum. This will cause the build failed as the types are not correctly mapped. Below are the two missing field types we found in our generated classes.
```
salesforceType: SalesforceFieldType.TIME
salesforceType: SalesforceFieldType.ENCRYPTEDSTRING
```

In this PR, I added these two field types into `SalesforceFieldType` enum. But I'm not sure if any others are missing as well.

I really appreciate your excellent work for `ts-force`. Please feel free to let me know if you need more information about this PR.

Regards!