### PR TITLE
Fix field mapping camelcase

### DIFF
--- a/ts-force-gen/package-lock.json
+++ b/ts-force-gen/package-lock.json
@@ -137,6 +137,12 @@
       "resolved": "https://registry.npmjs.org/@types/jsforce/-/jsforce-1.9.2.tgz",
       "integrity": "sha512-ZRRPNf/e44QnFI8VEsPxzrM/+Y5vx/HGsMI8qE4JvBHDkSfoFWAdZ93uW6Oh3sHmcoShexcoTH9gufihTgYBLQ=="
     },
+    "@types/lodash": {
+      "version": "4.14.149",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "2.2.43",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.43.tgz",

--- a/ts-force-gen/package.json
+++ b/ts-force-gen/package.json
@@ -37,6 +37,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.4",
     "@types/cli-spinner": "^0.2.0",
+    "@types/lodash": "^4.14.149",
     "@types/mocha": "^2.2.43",
     "@types/nock": "^8.2.1",
     "@types/node": "^8.0.4",
@@ -55,6 +56,7 @@
     "@salesforce/core": "^1.3.3",
     "cli-spinner": "0.2.10",
     "dotenv": "^4.0.0",
+    "lodash": "^4.17.15",
     "minimist": "^1.2.0",
     "ts-morph": "^2.1.0",
     "tslib": "^1.6.0"

--- a/ts-force-gen/src/sObjectGenerator.ts
+++ b/ts-force-gen/src/sObjectGenerator.ts
@@ -1,4 +1,4 @@
-
+import { camelCase } from 'lodash';
 import { ChildRelationship, Field, Rest, SalesforceFieldType, SFieldProperties, SObjectDescribe } from '../../ts-force';
 import { ClassDeclaration, DecoratorStructure, JSDocStructure, PropertyDeclarationStructure, Scope, SourceFile, ImportDeclarationStructure, StructureKind, WriterFunctions } from 'ts-morph';
 import { SObjectConfig } from './config';
@@ -275,7 +275,8 @@ export class SObjectGenerator {
       return fieldMapping.propName;
     } else if (sobConfig.autoConvertNames) {
       let s = cleanAPIName(apiName, sobConfig.stripNamespaces);
-      return apiName.charAt(0).toLowerCase() + s.slice(1) + (reference && !apiName.endsWith('Id') ? 'Id' : '');
+      s += reference && !apiName.endsWith('Id') ? 'Id' : '';
+      return camelCase(s);
     } else {
       return apiName;
     }


### PR DESCRIPTION
Previously the wrong first letter was being used because it was pulling from the raw, uncleaned API name.

Using lodash's camelCase we can handle other cases too:
| API | Before | Now | Best
-|-|-|-
npe01__SYSTEMIsIndividual__c | sYSTEMIsIndividual | systemIsIndividual | _same as now_
No_of_Years_as_a_Donor__c | noofYearsasaDonor | noOfYearsAsADonor |  _same as now_
Do_Not_Invite_to_forWORD__c | doNotInvitetoforWORD | doNotInviteToForWord | doNotInviteToForWORD
Children_s_Names_and_DOB__c | childrensNamesandDOB | childrenSNamesAndDob | childrensNamesAndDOB

It doesn't handle all cases as noted with difference between _now_ and _best_, but I think it gets closer.