### PR TITLE
allow using `ts-force` and `ts-force-gen` in a project with `"strict"` mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
   "name": "ts-force-project",
-  "version": "2.5.1",
+  "version": "2.7.0",
   "lockfileVersion": 1
 }

--- a/ts-force-gen/src/sObjectGenerator.ts
+++ b/ts-force-gen/src/sObjectGenerator.ts
@@ -391,6 +391,7 @@ export class SObjectGenerator {
                         name: this.sanitizeProperty(relatedSobConfig, field.relationshipName, false),
                         type: referenceClass,
                         scope: Scope.Public,
+                        hasExclamationToken: true,
                         decorators: [
                             this.generateDecorator(decoratorProps)
                         ],

--- a/ts-force/src/rest/sObjectDecorators.ts
+++ b/ts-force/src/rest/sObjectDecorators.ts
@@ -33,7 +33,7 @@ export class SFieldProperties {
     public apiName: string;
     public updateable: boolean;
     public createable: boolean;
-    public reference: () => { new(): RestObject; };
+    public reference?: () => { new(): RestObject; };
     public required: boolean;
     public externalId: boolean;
     public childRelationship: boolean;


### PR DESCRIPTION
Currently when using `ts-force-gen` it generates class properties that are not initialized in a way that's [currently] statically analyzable by the TS compiler.

In addition, the `reference` property of `SFieldProperties` is sometimes generated as `undefined`.

This is fine in projects that don't use [`"strictNullChecks": true`](https://www.typescriptlang.org/tsconfig#strictNullChecks) (or [`"strict": true`](https://www.typescriptlang.org/tsconfig#strict), which includes it).

This RP aims to fix issues and allow using strict mode in TS projects that want to use `ts-force`, without needing to further exit their generated files by `ts-gen-force` or by patching `ts-force`.

The current alternative we use is to patch `ts-force` using [`patch-package`](https://github.com/ds300/patch-package):
```diff
diff --git a/node_modules/ts-force/build/rest/sObjectDecorators.d.ts b/node_modules/ts-force/build/rest/sObjectDecorators.d.ts
index d376fc6..a6c6ea9 100644
--- a/node_modules/ts-force/build/rest/sObjectDecorators.d.ts
+++ b/node_modules/ts-force/build/rest/sObjectDecorators.d.ts
@@ -29,7 +29,7 @@ export declare class SFieldProperties {
     apiName: string;
     updateable: boolean;
     createable: boolean;
-    reference: () => {
+    reference?: () => {
         new (): RestObject;
     };
     required: boolean;
```

and to add `@ts-ignore` on all property initializations in generated classes. e.g.:
```ts
export class Account {
  ...
  constructor(fields?: AccountFields, restInstance?: Rest) {
    super("Account", restInstance);
    // @ts-ignore
    this.contacts = void 0;
	
	...
  }
}
```