### PR TITLE
Allow sending `httpHeaders` in composite requests

### DIFF
--- a/ts-force/src/rest/composite/composite.ts
+++ b/ts-force/src/rest/composite/composite.ts
@@ -7,6 +7,7 @@ import { BaseConfig } from '../../auth/baseConfig';
 export interface CompositeRequest extends BatchRequest {
   referenceId: string;
   body?: any;
+  httpHeaders?: Record<string, string>
 }
 
 export interface CompositePayload {


### PR DESCRIPTION
[Docs](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/requests_composite.htm#subrequest)

We regularly use the `If-Unmodifed-Since` header to discard stale changes in our system

Couldn't see any tests or other places this affects, lmk if anything else needs doing