### PR TITLE
Swap Travis for Github Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "lts"
+      - run: npm ci
+      - run: npm run ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - "stable"
-install:
-  - npm install
-  - npm run ci


### PR DESCRIPTION
Fixes #100 

I swapped `npm install` for `npm ci` to [prevent package-lock.json changes](https://docs.npmjs.com/cli/v8/commands/npm-ci), but otherwise this should be 1:1

I can't see the old Travis runs though, so unsure if there are e.g. secrets that need adding to this repo to keep tests passing