### PR TITLE
patch: use nullish coalescing for autoConvertNames

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-force-project",
-  "version": "3.4.0",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-force-project",
-      "version": "3.4.0",
+      "version": "3.5.1",
       "hasInstallScript": true,
       "license": "ISC"
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-force-project",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "",
   "scripts": {
     "postinstall": "cd ts-force && npm install && npm run build && cd ../ts-force-gen && npm install",

--- a/ts-force-gen/package-lock.json
+++ b/ts-force-gen/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-force-gen",
-  "version": "3.4.1",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-force-gen",
-      "version": "3.4.1",
+      "version": "3.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@salesforce/core": "^2.12.3",

--- a/ts-force-gen/package.json
+++ b/ts-force-gen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-force-gen",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Code generation for ts-force",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/ts-force-gen/src/index.ts
+++ b/ts-force-gen/src/index.ts
@@ -247,7 +247,7 @@ async function generate (config: Config) {
       objConfig.enforcePicklistValues = config.enforcePicklistValues;
     }
 
-    objConfig.autoConvertNames = objConfig.autoConvertNames || true;
+    objConfig.autoConvertNames = objConfig.autoConvertNames ?? true;
     objConfig.className = objConfig.className || sanitizeClassName(objConfig);
 
     return objConfig;

--- a/ts-force/package-lock.json
+++ b/ts-force/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-force",
-  "version": "3.4.2",
+  "version": "3.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-force",
-      "version": "3.4.2",
+      "version": "3.5.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/cometd": "^4.0.4",

--- a/ts-force/package.json
+++ b/ts-force/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-force",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "a typescript client for connecting with salesforce APIs",
   "main": "build/index.js",
   "typings": "build/index.d.ts",


### PR DESCRIPTION
Use nullish coalescing to honor user setting. The logical OR treats null, undefined, empty string, and false as falsy value which will always set the autoConvertNames to true when user set it to false